### PR TITLE
Ignore models containing '_model_all' in handle_models

### DIFF
--- a/test.py
+++ b/test.py
@@ -2,33 +2,33 @@ from typing import Optional
 import requests
 
 cookies = {
-    "__Secure-Install": "36ae2011-5d35-4273-9d08-d42eb458331f",
-    "cnfdVisitorId": "6cefd47c-0d9b-4ce7-9bc9-34c913d0b90b",
-    "didomi_token": "eyJ1c2VyX2lkIjoiMTk4NmE1ZmYtNjUzNi02OGEyLWJlMDEtNTBlOGQ5OWVhNjA1IiwiY3JlYXRlZCI6IjIwMjUtMDgtMDJUMTA6NDI6MTAuNjQzWiIsInVwZGF0ZWQiOiIyMDI1LTA4LTAyVDEwOjQyOjEyLjg3M1oiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzpsYmNmcmFuY2UiLCJjOmdvb2dsZWFuYS00VFhuSmlnUiIsImM6cHVycG9zZWxhLTN3NFpmS0tEIiwiYzptNnB1YmxpY2ktdFhUWUROQWMiLCJjOmFmZmlsaW5ldCIsImM6c3BvbmdlY2VsbC1ueXliQUtIMiIsImM6dGlrdG9rLXJLQVlEZ2JIIiwiYzp6YW5veC1hWVl6NnpXNCIsImM6cGludGVyZXN0IiwiYzpwcmViaWRvcmctSGlqaXJZZGIiLCJjOmlnbml0aW9uby1MVkFNWmRuaiIsImM6ZGlkb21pIiwiYzpsYmNmcmFuY2UtSHkza1lNOUYiXX0sInB1cnBvc2VzIjp7ImVuYWJsZWQiOlsiZXhwZXJpZW5jZXV0aWxpc2F0ZXVyIiwibWVzdXJlYXVkaWVuY2UiLCJwZXJzb25uYWxpc2F0aW9ubWFya2V0aW5nIiwicHJpeCIsImRldmljZV9jaGFyYWN0ZXJpc3RpY3MiLCJjb21wYXJhaXNvLVkzWnkzVUV4IiwiZ2VvbG9jYXRpb25fZGF0YSJdfSwidmVuZG9yc19saSI6eyJlbmFibGVkIjpbImdvb2dsZSIsImM6cHVycG9zZWxhLTN3NFpmS0tEIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkRDS0FnQUZrQTl3Q1N3SWtnUlRBNmNDQmdFVkFKclFVR0FvUkJYT0N3WUZ0NExsZ1lSQUEuRENLQWdBRmtBOXdDU3dJa2dSVEE2Y0NCZ0VWQUpyUVVHQW9SQlhPQ3dZRnQ0TGxnWVJBQSJ9",
-    "euconsent-v2": "CQVhVIAQVhVIAAHABBENB1FsAP_gAELgAAAAKENB7CfdQSFiUbJlAOtAYQxP4BAiogAABgABgwwBCBLAMIwEhGAIIADAAAACGBAAICBAAQBlCADAAAAAIAAAACAEAAAAARAAJiAAAEAAAmBICABICYAAAQAQgkiEAAEAgAIAAAogSEgAAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAgAAAAAACAAAAAAEAFAAAAAAAAAAAAAAAAAMAAAAAAAABBQiBeAAsAB4AFQAOAAeABAACQAFQAMoAaABqADwAIYATAAoQBcAF0AMQAfAA_ACEAEdAMoAywBogDnAHcAP2Ag4CEAEWAIxARwBHQDRAGvANoAj0BNoCj4FNAU2ArIBbAC8wGSAMnAZZA1cDWAIAgQvAjsBQgAMUABgACC2gwADAAEFtCAAGAAILaAA.f_wACFwAAAAA",
-    "_ga": "GA1.1.1570886354.1754131333",
-    "FPID": "FPID2.2.ON2v7dK1aWcr2RhsSQNJeFJAO8dDHLq0N%2BgXlbs1oWM%3D.1754131333",
-    "FPAU": "1.2.1929399324.1754131334",
-    "deviceId": "e7475994-8fbe-4025-8fb5-384271b1796f",
-    "_gcl_au": "1.1.357828164.1754131338",
-    "_hjSessionUser_2783207": "eyJpZCI6ImE5MDM1OTM1LTVmMzAtNTNhOS05NDBhLWQ2Njk3OWQ0NTU1MCIsImNyZWF0ZWQiOjE3NTQxMzEzMzQ2NTgsImV4aXN0aW5nIjp0cnVlfQ==",
-    "_pcid": "%7B%22browserId%22%3A%22mdvdqyefgoxu2yfe%22%2C%22_t%22%3A%22mtjsohqa%7Cmdvdr0ea%22%7D",
-    "_pctx": "%7Bu%7DN4IgrgzgpgThIC4B2YA2qA05owMoBcBDfSREQpAeyRCwgEt8oBJAE0RXSwH18yBbfACsIlABYBHAEYAffqwBurGAAYoUkAF8gA",
-    "__gsas": "ID=663b8f9af9388491:T=1754207327:RT=1754207327:S=ALNI_MZs4JO4EEVJDS7sEm59bJIadUdcEA",
-    "ry_ry-l3b0nco_realytics": "eyJpZCI6InJ5X0VGOTAzQ0U2LTFFQzktNDYzOS04MzNBLUY1NzZFNjVCQTlCRSIsImNpZCI6bnVsbCwiZXhwIjoxNzg1NjY3MzM4NDA1LCJjcyI6MX0%3D",
-    "_fbp": "fb.1.1754207399461.156474195924338493",
-    "_scid": "6iUW8A2nKR2Dg6U2tXAVKRs60nB4zRuY",
-    "lg": "9",
-    "_ScCbts": "%5B%5D",
-    "_sctr": "1%7C1759359600000",
-    "FPLC": "8nNU0C5f4hoxYeNiflIFiEon0o%2B%2FcVAkyiCsSAHo8m3a7ueYv%2FW8eCKHzIQW3V9gQ0S%2Fgd0WnkMM0R4vX2WBLSgMiNOxa5MFEGddO1rcYX0LyJQvk1QfEEs8KlpVXw%3D%3D",
-    "_scid_r": "_KUW8A2nKR2Dg6U2tXAVKRs60nB4zRuYcGgijw",
-    "cto_bundle": "sYCV-19FbUVLbFRBR1hoRjVkc0V1UnlqUURPMXRGTVJsckJKaEZ6YWlheXdGYlJRdUF1VTlmU0FoamNsV3pqaVllUUpyRTVaVUFtN3Vnb0tINWxDQ09XQTRKdjJTMVNmWCUyQktTSnNZWFBPWUtRM1hvTnUlMkZkUjhMSU5rNlI2czJDVmpyZVhIb3B1NDlKbCUyRlV5SWE1WjNGQ0JSMk9MTnFFeTIwZ3N4aEtEVVpzbTlCOWMlM0Q",
-    "__gads": "ID=aacc7c3b980ef105:T=1754207334:RT=1759828353:S=ALNI_MbkArq2M_cUnYFwLV1ZEZXIAP9Tfw",
-    "__gpi": "UID=00001243a1aa4db2:T=1754207334:RT=1759828353:S=ALNI_MYTmGBVUQA82DutdqJJcnE5S1VGcg",
-    "__eoi": "ID=6a69744913b00b24:T=1754207334:RT=1759828353:S=AA-AfjZjG2ffcw1fDjRmsFKHAx6I",
-    "_ga_Z707449XJ2": "GS2.1.s1759827887$o22$g1$t1759828458$j54$l0$h301494421",
-    "datadome": "4T3~mI37V3vBV4KHYU4U0P3F0uDCqIkfDX5Y_HMhR6UQJsR9l01o0FT_MgL7zvon2jkCjx7FST_1qnbuSGSUxIJ1QSIPvyInB~b395dX4YJ6Kh6b6tDrCDPPKEK73k5k",
+    '__Secure-Install': '36ae2011-5d35-4273-9d08-d42eb458331f',
+    'cnfdVisitorId': '6cefd47c-0d9b-4ce7-9bc9-34c913d0b90b',
+    'didomi_token': 'eyJ1c2VyX2lkIjoiMTk4NmE1ZmYtNjUzNi02OGEyLWJlMDEtNTBlOGQ5OWVhNjA1IiwiY3JlYXRlZCI6IjIwMjUtMDgtMDJUMTA6NDI6MTAuNjQzWiIsInVwZGF0ZWQiOiIyMDI1LTA4LTAyVDEwOjQyOjEyLjg3M1oiLCJ2ZW5kb3JzIjp7ImVuYWJsZWQiOlsiZ29vZ2xlIiwiYzpsYmNmcmFuY2UiLCJjOmdvb2dsZWFuYS00VFhuSmlnUiIsImM6cHVycG9zZWxhLTN3NFpmS0tEIiwiYzptNnB1YmxpY2ktdFhUWUROQWMiLCJjOmFmZmlsaW5ldCIsImM6c3BvbmdlY2VsbC1ueXliQUtIMiIsImM6dGlrdG9rLXJLQVlEZ2JIIiwiYzp6YW5veC1hWVl6NnpXNCIsImM6cGludGVyZXN0IiwiYzpwcmViaWRvcmctSGlqaXJZZGIiLCJjOmlnbml0aW9uby1MVkFNWmRuaiIsImM6ZGlkb21pIiwiYzpsYmNmcmFuY2UtSHkza1lNOUYiXX0sInB1cnBvc2VzIjp7ImVuYWJsZWQiOlsiZXhwZXJpZW5jZXV0aWxpc2F0ZXVyIiwibWVzdXJlYXVkaWVuY2UiLCJwZXJzb25uYWxpc2F0aW9ubWFya2V0aW5nIiwicHJpeCIsImRldmljZV9jaGFyYWN0ZXJpc3RpY3MiLCJjb21wYXJhaXNvLVkzWnkzVUV4IiwiZ2VvbG9jYXRpb25fZGF0YSJdfSwidmVuZG9yc19saSI6eyJlbmFibGVkIjpbImdvb2dsZSIsImM6cHVycG9zZWxhLTN3NFpmS0tEIl19LCJ2ZXJzaW9uIjoyLCJhYyI6IkRDS0FnQUZrQTl3Q1N3SWtnUlRBNmNDQmdFVkFKclFVR0FvUkJYT0N3WUZ0NExsZ1lSQUEuRENLQWdBRmtBOXdDU3dJa2dSVEE2Y0NCZ0VWQUpyUVVHQW9SQlhPQ3dZRnQ0TGxnWVJBQSJ9',
+    'euconsent-v2': 'CQVhVIAQVhVIAAHABBENB1FsAP_gAELgAAAAKENB7CfdQSFiUbJlAOtAYQxP4BAiogAABgABgwwBCBLAMIwEhGAIIADAAAACGBAAICBAAQBlCADAAAAAIAAAACAEAAAAARAAJiAAAEAAAmBICABICYAAAQAQgkiEAAEAgAIAAAogSEgAAAAAHAAAAAAAAAAAAAAAAAEAAAAAAAAAAgAAAAAACAAAAAAEAFAAAAAAAAAAAAAAAAAMAAAAAAAABBQiBeAAsAB4AFQAOAAeABAACQAFQAMoAaABqADwAIYATAAoQBcAF0AMQAfAA_ACEAEdAMoAywBogDnAHcAP2Ag4CEAEWAIxARwBHQDRAGvANoAj0BNoCj4FNAU2ArIBbAC8wGSAMnAZZA1cDWAIAgQvAjsBQgAMUABgACC2gwADAAEFtCAAGAAILaAA.f_wACFwAAAAA',
+    '_ga': 'GA1.1.1570886354.1754131333',
+    'FPID': 'FPID2.2.ON2v7dK1aWcr2RhsSQNJeFJAO8dDHLq0N%2BgXlbs1oWM%3D.1754131333',
+    'FPAU': '1.2.1929399324.1754131334',
+    'deviceId': 'e7475994-8fbe-4025-8fb5-384271b1796f',
+    '_gcl_au': '1.1.357828164.1754131338',
+    '_hjSessionUser_2783207': 'eyJpZCI6ImE5MDM1OTM1LTVmMzAtNTNhOS05NDBhLWQ2Njk3OWQ0NTU1MCIsImNyZWF0ZWQiOjE3NTQxMzEzMzQ2NTgsImV4aXN0aW5nIjp0cnVlfQ==',
+    '_pcid': '%7B%22browserId%22%3A%22mdvdqyefgoxu2yfe%22%2C%22_t%22%3A%22mtjsohqa%7Cmdvdr0ea%22%7D',
+    '_pctx': '%7Bu%7DN4IgrgzgpgThIC4B2YA2qA05owMoBcBDfSREQpAeyRCwgEt8oBJAE0RXSwH18yBbfACsIlABYBHAEYAffqwBurGAAYoUkAF8gA',
+    '__gsas': 'ID=663b8f9af9388491:T=1754207327:RT=1754207327:S=ALNI_MZs4JO4EEVJDS7sEm59bJIadUdcEA',
+    'ry_ry-l3b0nco_realytics': 'eyJpZCI6InJ5X0VGOTAzQ0U2LTFFQzktNDYzOS04MzNBLUY1NzZFNjVCQTlCRSIsImNpZCI6bnVsbCwiZXhwIjoxNzg1NjY3MzM4NDA1LCJjcyI6MX0%3D',
+    '_fbp': 'fb.1.1754207399461.156474195924338493',
+    '_scid': '6iUW8A2nKR2Dg6U2tXAVKRs60nB4zRuY',
+    'lg': '9',
+    '_ScCbts': '%5B%5D',
+    '_sctr': '1%7C1759359600000',
+    'FPLC': '8nNU0C5f4hoxYeNiflIFiEon0o%2B%2FcVAkyiCsSAHo8m3a7ueYv%2FW8eCKHzIQW3V9gQ0S%2Fgd0WnkMM0R4vX2WBLSgMiNOxa5MFEGddO1rcYX0LyJQvk1QfEEs8KlpVXw%3D%3D',
+    'cto_bundle': 'M67pI19FbUVLbFRBR1hoRjVkc0V1UnlqUURIZGRGVWZlM0ZBUFY2WEwlMkJnVGJBJTJCQ3hBM204ZEMzZGp5YWR1UVBuV2wxRnZDJTJGaXlCSmVZWiUyRm0lMkZTSTk2ZnZZT0hsS21Sa1pwQnpQdHVLczhzZWMxQjlCa0JYaDM4dE5DMzklMkZPUjZlWTh6eCUyRlpJJTJCcVhzTUpBNk9FYXo0emNzU3olMkZtMHRjOVNZd21FM0w3S0Z3UUVzOUklM0Q',
+    '_scid_r': '_qUW8A2nKR2Dg6U2tXAVKRs60nB4zRuYcGgigQ',
+    '_ga_Z707449XJ2': 'GS2.1.s1759846567$o26$g0$t1759846567$j60$l0$h672542517',
+    '__gads': 'ID=aacc7c3b980ef105:T=1754207334:RT=1759846578:S=ALNI_MbkArq2M_cUnYFwLV1ZEZXIAP9Tfw',
+    '__gpi': 'UID=00001243a1aa4db2:T=1754207334:RT=1759846578:S=ALNI_MYTmGBVUQA82DutdqJJcnE5S1VGcg',
+    '__eoi': 'ID=6a69744913b00b24:T=1754207334:RT=1759846578:S=AA-AfjZjG2ffcw1fDjRmsFKHAx6I',
+    'datadome': 'oByi0lZUHjjWwAhw~trg93VaLF8VHfDi1kjHn6Th2DZeOH3iOR2lUl0V5RquvjNxLqPRXIxQbTS~GV2AAhM3fCeeUBqmTc4hB_oIcsbuGU70YfVXQFfsGozhGyra7~wg',
 }
 
 headers = {
@@ -55,26 +55,26 @@ def get_filtre(
     model: Optional[str] = None,
     color: Optional[str] = None,
     vehicle_type: Optional[str] = None,
-    full: Optional[str] = None,
+    fuel: Optional[str] = None,
+    gearbox: Optional[str] = None,
+    owner_type: Optional[str] = None,
 ):
     """
-    Sends a request to the Leboncoin API to retrieve the list of filters (models, colors, types)
+    Sends a request to the Leboncoin API to retrieve the list of filters (models, colors, types, fuels, gearbox)
     available for a given brand, model, or color.
     """
     json_data = {
         "filters": {
-            "category": {
-                "id": "2",
-            },
+            "category": {"id": "2"},
             "enums": {
-                "ad_type": [
-                    "offer",
-                ],
+                "ad_type": ["offer"],
                 "u_car_brand": [brand],
                 "u_car_model": [model] if model else [],
                 "vehicule_color": [color] if color else [],
                 "vehicle_type": [vehicle_type] if vehicle_type else [],
-                "full": [full] if full else [],
+                "fuel": [fuel] if fuel else [],
+                "gearbox": [gearbox] if gearbox else [],
+                "owner_type": [owner_type] if owner_type else [],
             },
             "ranges": {},
         },
@@ -82,6 +82,7 @@ def get_filtre(
         "limit_alu": 0,
         "sort_by": "relevance",
     }
+
     response = requests.post(
         "https://api.leboncoin.fr/finder/search",
         cookies=cookies,
@@ -90,16 +91,27 @@ def get_filtre(
     )
     response.raise_for_status()
     json_data = response.json()
+
     aggregations = json_data.get("aggregations")
-    models = aggregations.get("u_car_model", {})
+    models = aggregations.get("u_car_model", {}) or {}
     colors = aggregations.get("vehicule_color", {})
     types = aggregations.get("vehicle_type", {})
+    fuels = aggregations.get("fuel", {})
+    gearboxes = aggregations.get("gearbox", {})
+    owner_types = aggregations.get("owner_type", {})
+    
+
     return {
         "models": models,
         "colors": colors,
         "types": types,
+        "fuels": fuels,
+        "gearboxes": gearboxes,
+        "owner_types": owner_types
+        
     }
 
+over_3000_filters = []
 
 # 🔹 Function placeholder: retrieves the real data for a given filter combination
 # ----------------------------------------------------------
@@ -110,10 +122,9 @@ def get_filtre(
 # - Store or process this data (e.g., save it in a CSV or database).
 # ----------------------------------------------------------
 
-
 def get_data(filtre: dict) -> None:
     print("-----------------")
-    # print(filtre)
+    print(filtre)
     pass
 
 
@@ -123,6 +134,10 @@ def handle_models(brand: str, models: dict):
     or to retrieve data directly if the total is small enough.
     """
     for model, total_number in models.items():
+        if "_model_all" in model:
+            print(f"Ignoring model: {model}")
+            continue  # on ignore ce modèle
+
         print("--------------MODEL-------------------")
         # print(f"Model - {model} | Total - {total_number}")
 
@@ -133,14 +148,13 @@ def handle_models(brand: str, models: dict):
             color_filters = get_filtre(brand, model=model)
             handle_colors(brand, model, color_filters["colors"])
 
-
 def handle_colors(brand: str, model: str, colors: dict):
     """
     Iterates over colors for a given model.
     """
     for color, total_number in colors.items():
         print("--------------COLOR-------------------")
-        # print(f"Color - {color} | Total - {total_number}")
+        #print(f"Color - {color} | Total - {total_number}")
 
         if total_number < 3000:
             filtre = build_filtre(brand, model=model, color=color)
@@ -163,6 +177,92 @@ def handle_types(brand: str, model: str, color: str, types: dict):
                 brand, model=model, color=color, vehicle_type=vehicle_type
             )
             get_data(filtre)
+        else:
+            fuel_filters = get_filtre(
+                brand, model=model, color=color, vehicle_type=vehicle_type
+            )
+            handle_fuels(
+                brand, model, color, vehicle_type, fuel_filters["fuels"]
+            )
+
+
+def handle_fuels(brand: str, model: str, color: str, vehicle_type: str, fuels: dict):
+    """
+    Iterate over fuels for a given model/color/type combination.
+    """
+    for fuel, total_number in fuels.items():
+        print("--------------FUEL-------------------")
+
+        if total_number < 3000:
+            filtre = build_filtre(
+                brand, model=model, color=color, vehicle_type=vehicle_type, fuel=fuel
+            )
+            get_data(filtre)
+        else:
+            # 🔹 Appel suivant : niveau "gearbox"
+            gearbox_filters = get_filtre(
+                brand, model=model, color=color, vehicle_type=vehicle_type, fuel=fuel
+            )
+            handle_gearboxes(
+                brand, model, color, vehicle_type, fuel, gearbox_filters["gearboxes"]
+            )
+       
+
+def handle_gearboxes(brand: str, model: str, color: str, vehicle_type: str, fuel: str, gearboxes: dict):
+    for gearbox, total_number in gearboxes.items():
+        print("--------------GEARBOX-------------------")
+
+        if total_number < 3000:
+            get_data(build_filtre(
+                brand, model=model, color=color, vehicle_type=vehicle_type, fuel=fuel, gearbox=gearbox
+            ))
+        else:
+            # 🔹 Si encore >3000 → descente au niveau "owner_type"
+            owner_filters = get_filtre(
+                brand, model=model, color=color, vehicle_type=vehicle_type, fuel=fuel, gearbox=gearbox
+            )
+            handle_owner_types(
+                brand, model, color, vehicle_type, fuel, gearbox, owner_filters["owner_types"]
+            )
+
+
+
+def handle_owner_types(
+    brand: str, model: str, color: str, vehicle_type: str, fuel: str, gearbox: str, owner_types: dict
+):
+    """
+    Dernier niveau : type de propriétaire (particulier/professionnel)
+    """
+    for owner_type, total_number in owner_types.items():
+        print("--------------OWNER TYPE-------------------")
+
+        if total_number < 3000:
+            get_data(build_filtre(
+                brand,
+                model=model,
+                color=color,
+                vehicle_type=vehicle_type,
+                fuel=fuel,
+                gearbox=gearbox,
+                owner_type=owner_type,
+            ))
+        else:
+            print(f"Trop d'annonces pour owner_type='{owner_type}' ({total_number} > 3000)")
+            over_3000_filters.append(
+                {
+                    "brand": brand,
+                    "model": model,
+                    "color": color,
+                    "type": vehicle_type,
+                    "fuel": fuel,
+                    "gearbox": gearbox,
+                    "owner_type": owner_type,
+                    "total": total_number,
+                }
+            )
+
+
+
 
 
 def build_filtre(
@@ -170,7 +270,9 @@ def build_filtre(
     model: Optional[str] = None,
     color: Optional[str] = None,
     vehicle_type: Optional[str] = None,
-    full: Optional[str] = None,
+    fuel: Optional[str] = None,
+    gearbox: Optional[str] = None,
+    owner_type: Optional[str] = None,
     limit: int = 100,
     offset: int = 0,
 ) -> dict:
@@ -181,8 +283,12 @@ def build_filtre(
         enums["vehicule_color"] = [color]
     if vehicle_type:
         enums["vehicle_type"] = [vehicle_type]
-    if full:
-        enums["full"] = [full]
+    if fuel:
+        enums["fuel"] = [fuel]
+    if gearbox:
+        enums["gearbox"] = [gearbox]
+    if owner_type:
+        enums["owner_type"] = [owner_type]
 
     return {
         "filters": {"category": {"id": "2"}, "enums": enums},
@@ -194,34 +300,21 @@ def build_filtre(
     }
 
 
-def handle_full(brand: str, fulls: dict):
-    """
-    Iterates over 'full' filter options for a given brand.
-    If total number exceeds 3000, just prints a message.
-    """
-    for full, total_number in fulls.items():
-        print("--------------FULL-------------------")
-        # print(f"Full - {full} | Total - {total_number}")
-
-        if total_number < 3000:
-            filtre = build_filtre(brand, full=full)
-            get_data(filtre)
-        else:
-            # If still more than 3000, we just log it
-            print(
-                f"Too many ads for full='{full}' ({total_number} > 3000), skipping detailed fetch."
-            )
-
-
 def main(brand: str):
     """
     Main entry point — starts the collection process for a given car brand.
     """
     model_filters = get_filtre(brand)
-    models = model_filters["models"]
-    handle_models(brand, models)
-    full_filters = get_filtre(brand, full="full")
-    handle_full(brand, full_filters.get("full", {}))
+    handle_models(brand, model_filters["models"])
+
+    print("\n===============================")
+    print(" Filtres dépassant 3000 annonces")
+    print("===============================")
+    if over_3000_filters:
+        for f in over_3000_filters:
+            print(f)
+    else:
+        print(" Aucun filtre ne dépasse 3000 annonces.")
 
 
-main("VOLKSWAGEN")
+main("RENAULT")


### PR DESCRIPTION
All models containing '_model_all' are now ignored in the handle_models function to prevent unnecessary data retrieval.
